### PR TITLE
Fixing environment param

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -30,7 +30,7 @@ let [cmd, ... files] = program.args;
 
 // Load config from config.yml
 let env = program.env ? program.env : null;
-env = process.env.ENV ? process.env.ENV : env;
+env = env ? env : process.env.ENV;
 let config;
 try {
   config = require('config-yml').load(env);


### PR DESCRIPTION
Currently, the environment param is ignored and always using the default environment instead of the environment from the param. This PR fixes the environment param.